### PR TITLE
9 UI implement moving card

### DIFF
--- a/src/solitaire/main.py
+++ b/src/solitaire/main.py
@@ -15,6 +15,13 @@ BLACK = (0, 0, 0)
 WHITE = (255, 255, 255)
 RED = (255, 0, 0)
 GRAY = (100, 100, 100)
+TABLEAU_Y = CARD_MARGIN * 2 + CARD_HEIGHT
+TABLEAU_X_START = CARD_MARGIN
+FOUNDATION_X_START = SCREEN_WIDTH - (4 * (CARD_WIDTH + CARD_MARGIN)) - CARD_MARGIN
+STOCK_X = CARD_MARGIN
+STOCK_Y = CARD_MARGIN
+WASTE_X = CARD_MARGIN + CARD_WIDTH + CARD_MARGIN
+WASTE_Y = CARD_MARGIN
 
 class Renderer:
     def __init__(self, screen):
@@ -42,43 +49,104 @@ class Renderer:
         rect = pygame.Rect(x, y, CARD_WIDTH, CARD_HEIGHT)
         pygame.draw.rect(self.screen, (0, 100, 0), rect, 2)
 
-    def draw_board(self, board):
-        # Draw Stock and Waste
-        stock_x = CARD_MARGIN
-        stock_y = CARD_MARGIN
+    def draw_board(self, board, dragging_info=None):
+        # Draw Stock
         if board.stock:
-            self.draw_card(board.stock[0], stock_x, stock_y)
+            # Stock is always face-down
+            rect = pygame.Rect(STOCK_X, STOCK_Y, CARD_WIDTH, CARD_HEIGHT)
+            pygame.draw.rect(self.screen, GRAY, rect)
+            pygame.draw.rect(self.screen, BLACK, rect, 2)
         else:
-            self.draw_empty_slot(stock_x, stock_y)
+            self.draw_empty_slot(STOCK_X, STOCK_Y)
             
-        waste_x = stock_x + (CARD_WIDTH + CARD_MARGIN)
-        waste_y = CARD_MARGIN
+        # Draw Waste (Fanned out top 3)
         if board.waste:
-            self.draw_card(board.waste[-1], waste_x, waste_y)
+            waste_to_draw = board.waste[-3:]
+            # If the top card is being dragged, we don't draw it in its original place
+            dragging_from_waste = dragging_info and dragging_info['source']['type'] == 'waste'
+            
+            num_cards = len(waste_to_draw)
+            for i, card in enumerate(waste_to_draw):
+                # If it's the top card and it's being dragged, skip it
+                if dragging_from_waste and i == num_cards - 1:
+                    continue
+                
+                # Offset each card slightly to the right to fan them
+                fan_offset = i * 20
+                self.draw_card(card, WASTE_X + fan_offset, WASTE_Y)
         else:
-            self.draw_empty_slot(waste_x, waste_y)
+            self.draw_empty_slot(WASTE_X, WASTE_Y)
 
-        # Draw Foundations on the right
-        found_end_x = SCREEN_WIDTH - CARD_MARGIN - CARD_WIDTH
-        for i, pile in enumerate(reversed(board.foundation)):
-            x = found_end_x - i * (CARD_WIDTH + CARD_MARGIN)
+        # Draw Foundations
+        for i, pile in enumerate(board.foundation):
+            x = FOUNDATION_X_START + i * (CARD_WIDTH + CARD_MARGIN)
             y = CARD_MARGIN
-            if pile:
+            # Check if foundation top card is being dragged
+            if dragging_info and dragging_info['source']['type'] == 'foundation' and dragging_info['source']['idx'] == i:
+                if len(pile) > 1:
+                    self.draw_card(pile[-2], x, y)
+                else:
+                    self.draw_empty_slot(x, y)
+            elif pile:
                 self.draw_card(pile[-1], x, y)
             else:
                 self.draw_empty_slot(x, y)
 
         # Draw Tableau
-        tableau_start_x = CARD_MARGIN
-        tableau_y = CARD_MARGIN * 2 + CARD_HEIGHT
         for i, pile in enumerate(board.tableau):
-            x = tableau_start_x + i * (CARD_WIDTH + CARD_MARGIN)
+            x = TABLEAU_X_START + i * (CARD_WIDTH + CARD_MARGIN)
             if not pile:
-                self.draw_empty_slot(x, tableau_y)
+                self.draw_empty_slot(x, TABLEAU_Y)
             else:
-                for j, card in enumerate(pile):
-                    # Stack cards vertically in tableau
-                    self.draw_card(card, x, tableau_y + j * 20)
+                # If dragging from this pile, only draw cards NOT being dragged
+                num_to_draw = len(pile)
+                if dragging_info and dragging_info['source']['type'] == 'tableau' and dragging_info['source']['idx'] == i:
+                    num_to_draw -= dragging_info['source']['num_cards']
+
+                for j in range(num_to_draw):
+                    card = pile[j]
+                    self.draw_card(card, x, TABLEAU_Y + j * 20)
+
+        # Draw dragging cards last
+        if dragging_info:
+            mouse_x, mouse_y = pygame.mouse.get_pos()
+            offset_x, offset_y = dragging_info['offset']
+            for j, card in enumerate(dragging_info['cards']):
+                self.draw_card(card, mouse_x - offset_x, mouse_y - offset_y + j * 20)
+
+def get_component_at_pos(pos):
+    """Returns (type, idx, num_cards) or None."""
+    x, y = pos
+    
+    # Check Stock
+    if STOCK_X <= x <= STOCK_X + CARD_WIDTH and STOCK_Y <= y <= STOCK_Y + CARD_HEIGHT:
+        return {"type": "stock", "idx": 0}
+
+    # Check Waste
+    num_waste = 0
+    # Assuming we can get access to board here to know the number of cards in waste, 
+    # but get_component_at_pos only takes pos.
+    # However, in main() we have the board.
+    # Let's adjust the detection to account for the fanning.
+    # The topmost card in waste is at WASTE_X + (min(3, len(waste))-1) * 20
+    # For now, let's keep it simple and check the general area.
+    # We'll refine it in the main loop where we have the board.
+    if WASTE_X <= x <= WASTE_X + CARD_WIDTH + 40 and WASTE_Y <= y <= WASTE_Y + CARD_HEIGHT:
+        return {"type": "waste", "idx": 0}
+
+    # Check Foundation
+    for i in range(4):
+        f_x = FOUNDATION_X_START + i * (CARD_WIDTH + CARD_MARGIN)
+        if f_x <= x <= f_x + CARD_WIDTH and CARD_MARGIN <= y <= CARD_MARGIN + CARD_HEIGHT:
+            return {"type": "foundation", "idx": i}
+
+    # Check Tableau
+    for i in range(7):
+        t_x = TABLEAU_X_START + i * (CARD_WIDTH + CARD_MARGIN)
+        if t_x <= x <= t_x + CARD_WIDTH and y >= TABLEAU_Y:
+            return {"type": "tableau", "idx": i}
+            
+    return None
 
 def main():
     pygame.init()
@@ -89,6 +157,11 @@ def main():
     board = Board()
     renderer = Renderer(screen)
     
+    dragging_info = None
+    
+    last_click_pos = None
+    last_click_time = 0
+    
     running = True
     while running:
         for event in pygame.event.get():
@@ -96,35 +169,98 @@ def main():
                 running = False
             elif event.type == pygame.MOUSEBUTTONDOWN:
                 if event.button == 1: # Left click
-                    mouse_x, mouse_y = event.pos
-                    # Check if Stock was clicked
-                    stock_x = CARD_MARGIN
-                    stock_rect = pygame.Rect(stock_x, CARD_MARGIN, CARD_WIDTH, CARD_HEIGHT)
-                    if stock_rect.collidepoint(mouse_x, mouse_y):
-                        if board.stock:
-                            # Draw from stock
-                            card = board.stock.popleft()
-                            # Cards in waste should be face down
-                            # If it was face up, flip it face down.
-                            if card.flipped:
-                                card.flip()
-                            board.waste.append(card)
-                            # Flip the next card in stock face-up
-                            if board.stock and not board.stock[0].flipped:
-                                board.stock[0].flip()
-                        elif board.waste:
-                            # Refill stock from waste if empty
-                            while board.waste:
-                                card = board.waste.pop()
-                                if card.flipped:
-                                    card.flip()
-                                board.stock.append(card) # append to end
-                            # Flip the first card of new stock face-up
-                            if board.stock and not board.stock[0].flipped:
-                                board.stock[0].flip()
-        
+                    last_click_pos = event.pos
+                    last_click_time = pygame.time.get_ticks()
+                    
+                    comp = get_component_at_pos(event.pos)
+                    if not comp:
+                        continue
+                    
+                    # Start dragging logic for everything
+                    source_type = comp['type']
+                    idx = comp['idx']
+                    
+                    cards_to_drag = []
+                    if source_type == 'waste' and board.waste:
+                        cards_to_drag = [board.waste[-1]]
+                    elif source_type == 'foundation' and board.foundation[idx]:
+                        cards_to_drag = [board.foundation[idx][-1]]
+                    elif source_type == 'tableau' and board.tableau[idx]:
+                        # Identify which card in the stack was clicked
+                        pile = board.tableau[idx]
+                        card_idx = (event.pos[1] - TABLEAU_Y) // 20
+                        card_idx = min(max(0, card_idx), len(pile) - 1)
+                        
+                        # Can only drag face-up cards
+                        if pile[card_idx].flipped:
+                            cards_to_drag = pile[card_idx:]
+                    
+                    if cards_to_drag:
+                        # Ensure card is flipped if it comes from waste
+                        # (Already flipped by Board when drawn, but let's be sure for visual consistency)
+                        if source_type == 'waste':
+                            cards_to_drag[0].flipped = True
+                        
+                        # Calculate offset (where within the card we clicked)
+                        # For tableau, we care about the card we clicked
+                        # For simplicity, just use the first card's position
+                        if source_type == 'tableau':
+                            pile = board.tableau[idx]
+                            start_x = TABLEAU_X_START + idx * (CARD_WIDTH + CARD_MARGIN)
+                            start_y = TABLEAU_Y + pile.index(cards_to_drag[0]) * 20
+                        elif source_type == 'waste':
+                            fan_offset = (min(3, len(board.waste)) - 1) * 20
+                            start_x = WASTE_X + fan_offset
+                            start_y = WASTE_Y
+                        else: # foundation (already handled by elif)
+                            start_x = FOUNDATION_X_START + idx * (CARD_WIDTH + CARD_MARGIN)
+                            start_y = CARD_MARGIN
+
+                        offset = (event.pos[0] - start_x, event.pos[1] - start_y)
+                        
+                        dragging_info = {
+                            "cards": cards_to_drag,
+                            "source": {"type": source_type, "idx": idx, "num_cards": len(cards_to_drag)},
+                            "offset": offset
+                        }
+
+            elif event.type == pygame.MOUSEBUTTONUP:
+                if event.button == 1:
+                    # Check for "click" (minimal movement and short time)
+                    curr_time = pygame.time.get_ticks()
+                    if last_click_pos:
+                        dx = abs(event.pos[0] - last_click_pos[0])
+                        dy = abs(event.pos[1] - last_click_pos[1])
+                        # If it was a short click without much movement
+                        if dx < 5 and dy < 5 and (curr_time - last_click_time) < 250:
+                            comp = get_component_at_pos(event.pos)
+                            if comp and (comp['type'] == 'stock' or comp['type'] == 'waste'):
+                                board.draw_from_stock()
+                                dragging_info = None # Cancel drag if it was intended as a click
+                    
+                    if dragging_info:
+                        dest = get_component_at_pos(event.pos)
+                        
+                        move_success = False
+                        if dest and dest['type'] in ['tableau', 'foundation']:
+                            source = dragging_info['source']
+                            move_success = board.move_card(
+                                source_type=source['type'],
+                                source_idx=source['idx'],
+                                dest_type=dest['type'],
+                                dest_idx=dest['idx'],
+                                num_cards=source['num_cards']
+                            )
+                        
+                        # If move failed and it was from waste, ensure it's still flipped
+                        if not move_success and dragging_info['source']['type'] == 'waste':
+                            dragging_info['cards'][0].flipped = True
+                        
+                        dragging_info = None
+                    last_click_pos = None
+
         screen.fill(BACKGROUND_COLOR)
-        renderer.draw_board(board)
+        renderer.draw_board(board, dragging_info)
         
         pygame.display.flip()
         clock.tick(FPS)

--- a/src/solitaire/main.py
+++ b/src/solitaire/main.py
@@ -1,5 +1,6 @@
 import pygame
 from solitaire.models.board import Board
+from solitaire.models.color import Color
 
 # Constants for the game window and layout
 SCREEN_WIDTH = 1000
@@ -37,11 +38,11 @@ class Renderer:
             pygame.draw.rect(self.screen, WHITE, rect)
             pygame.draw.rect(self.screen, BLACK, rect, 2)
             
-            color = RED if card.color == "Red" else BLACK
+            color = RED if card.color == Color.RED else BLACK
             
             # Full text representation of the card
             name_text = self.font.render(card._actual_name, True, color)
-            suit_text = self.font.render(card.suit, True, color)
+            suit_text = self.font.render(card.suit.label, True, color)
             self.screen.blit(name_text, (x + 5, y + 5))
             self.screen.blit(suit_text, (x + 5, y + 25))
 

--- a/src/solitaire/models/board.py
+++ b/src/solitaire/models/board.py
@@ -35,15 +35,120 @@ class Board:
         
         # tableau piles have the last card revealed to the user
         for pile in self.tableau:
-            if pile:
-                card = pile[-1]
-                if not card.flipped:
-                    card.flip()
+            self._ensure_top_card_flipped(pile)
 
-        # the first card in the stock should be revealed to the user
-        if self.stock:
-            if not self.stock[0].flipped:
-                self.stock[0].flip()
+    def _ensure_top_card_flipped(self, pile: list[Card] | deque[Card]):
+        """
+        Ensures the top card of a pile is flipped face up.
+        """
+        if pile:
+            card = pile[-1] if isinstance(pile, list) else pile[0]
+            if not card.flipped:
+                card.flip()
+
+    def draw_from_stock(self) -> bool:
+        """
+        Draws a card from the stock and moves it to the waste.
+        If the stock is empty, resets the stock by moving all cards from waste back to stock.
+        :return: True if successful, False otherwise
+        """
+        if not self.stock:
+            if not self.waste:
+                return False
+            # Reset stock: move waste back to stock
+            # In Solitaire, the waste is flipped back and put into stock
+            while self.waste:
+                card = self.waste.pop()
+                if card.flipped:
+                    card.flip()
+                self.stock.append(card)
+            
+            if self.stock:
+                # Stock is face-down by default
+                pass
+            return True
+
+        card = self.stock.popleft()
+        if not card.flipped:
+            card.flip()
+        self.waste.append(card)
+        
+        return True
+
+    def is_move_valid(self, source_type: str, source_idx: int, dest_type: str, dest_idx: int, num_cards: int = 1) -> bool:
+        """
+        Stub for move validation logic. Currently always returns True.
+        
+        :param source_type: Type of the source (tableau, foundation, waste)
+        :param source_idx: Index of the source pile (if applicable)
+        :param dest_type: Type of the destination (tableau, foundation)
+        :param dest_idx: Index of the destination pile (if applicable)
+        :param num_cards: Number of cards to move (relevant for tableau)
+        :return: True if move is valid, False otherwise
+        """
+        # Logic to "reject" a move will be implemented in a separate issue.
+        return True
+
+    def move_card(self, source_type: str, dest_type: str, source_idx: int = None, dest_idx: int = None, num_cards: int = 1):
+        """
+        Moves cards between board components.
+        
+        :param source_type: Type of the source (tableau, foundation, waste)
+        :param dest_type: Type of the destination (tableau, foundation)
+        :param source_idx: Index of the source pile
+        :param dest_idx: Index of the destination pile
+        :param num_cards: Number of cards to move
+        :return: True if move was successful, False otherwise
+        """
+        if not self.is_move_valid(source_type, source_idx, dest_type, dest_idx, num_cards):
+            return False
+
+        # Get source cards
+        cards_to_move = []
+        source_pile = None
+        
+        if source_type == "tableau":
+            source_pile = self.tableau[source_idx]
+            if len(source_pile) < num_cards:
+                return False
+            cards_to_move = source_pile[-num_cards:]
+            self.tableau[source_idx] = source_pile[:-num_cards]
+        elif source_type == "foundation":
+            source_pile = self.foundation[source_idx]
+            if not source_pile:
+                return False
+            cards_to_move = [source_pile.pop()]
+        elif source_type == "waste":
+            if not self.waste:
+                return False
+            cards_to_move = [self.waste.pop()]
+        else:
+            return False
+
+        # Get destination pile
+        dest_pile = None
+        if dest_type == "tableau":
+            dest_pile = self.tableau[dest_idx]
+        elif dest_type == "foundation":
+            dest_pile = self.foundation[dest_idx]
+        else:
+            # If invalid destination, return cards to source
+            if source_type == "tableau":
+                self.tableau[source_idx].extend(cards_to_move)
+            elif source_type == "foundation":
+                self.foundation[source_idx].extend(cards_to_move)
+            elif source_type == "waste":
+                self.waste.append(cards_to_move[0])
+            return False
+
+        # Apply move
+        dest_pile.extend(cards_to_move)
+
+        # Post-move cleanup: ensure top card of source tableau is flipped
+        if source_type == "tableau":
+            self._ensure_top_card_flipped(self.tableau[source_idx])
+
+        return True
 
     def print_board(self):
         """

--- a/src/solitaire/models/board.py
+++ b/src/solitaire/models/board.py
@@ -1,8 +1,9 @@
 from collections import deque
 
 from solitaire.models.deck import Deck
-
 from solitaire.models.card import Card
+from solitaire.models.suit import Suit
+from solitaire.models.color import Color
 
 
 class Board:
@@ -175,13 +176,18 @@ class Board:
 
     def print_foundation(self):
         suit_symbols = {
-            0: "\U00002664",  # Spades
-            1: "\U00002661",  # Hearts
-            2: "\U00002662",  # Diamonds
-            3: "\U00002667"  # Clubs
+            Suit.SPADES: "\U00002664",  # Spades
+            Suit.HEARTS: "\U00002661",  # Hearts
+            Suit.DIAMONDS: "\U00002662",  # Diamonds
+            Suit.CLUBS: "\U00002667"  # Clubs
         }
         for i, pile in enumerate(self.foundation):
             if len(pile) > 0:
                 pile[-1].print_unicode()
             else:
-                print(suit_symbols[i])
+                # This might need to be indexed differently if we want specific suit symbols for each foundation slot
+                # For now, let's keep the logic as it was (indexed by 0-3) if possible, 
+                # but it's better to use Suit enums.
+                # Assuming foundation[0] is Spades, 1 is Hearts, etc. based on the previous dictionary.
+                suits = [Suit.SPADES, Suit.HEARTS, Suit.DIAMONDS, Suit.CLUBS]
+                print(suit_symbols[suits[i]])

--- a/src/solitaire/models/card.py
+++ b/src/solitaire/models/card.py
@@ -1,34 +1,33 @@
+from solitaire.models.color import Color
+from solitaire.models.suit import Suit
+
 class Card:
     """
     Represents a single playing card in a deck.
     """
 
-    VALID_SUITS = ["Hearts", "Diamonds", "Spades", "Clubs"]
     NAMES = {
         1: "Ace", 2: "Two", 3: "Three", 4: "Four", 5: "Five",
         6: "Six", 7: "Seven", 8: "Eight", 9: "Nine", 10: "Ten",
         11: "Jack", 12: "Queen", 13: "King"
     }
 
-    def __init__(self, suit: str, value: int):
+    def __init__(self, suit: Suit, value: int):
         """
         Initializes a card with a suit and a numerical value (1-13).
         """
-        self.suit = suit.capitalize()
-        if self.suit not in Card.VALID_SUITS:
-            raise ValueError(f"Invalid suit: {self.suit}. Must be one of {Card.VALID_SUITS}")
+        if not isinstance(suit, Suit):
+            raise ValueError(f"Invalid suit: {suit}. Must be a Suit enum")
 
         if not (1 <= value <= 13):
             raise ValueError(f"Invalid value: {value}. Must be between 1 and 13")
 
+        self.suit = suit
         self.value = value
         self.flipped = False
 
         # Determine color based on suit
-        if self.suit in ["Hearts", "Diamonds"]:
-            self.color = "Red"
-        else:
-            self.color = "Black"
+        self.color = suit.color
 
         # Map numerical value to name
         self._actual_name = Card.NAMES.get(value, str(value))
@@ -58,10 +57,10 @@ class Card:
 
         # Base offsets for suits in the Unicode block
         suit_offsets = {
-            "Spades": 0x1F0A0,
-            "Hearts": 0x1F0B0,
-            "Diamonds": 0x1F0C0,
-            "Clubs": 0x1F0D0
+            Suit.SPADES: 0x1F0A0,
+            Suit.HEARTS: 0x1F0B0,
+            Suit.DIAMONDS: 0x1F0C0,
+            Suit.CLUBS: 0x1F0D0
         }
 
         if self.suit not in suit_offsets:
@@ -85,4 +84,4 @@ class Card:
         if not self.flipped:
             print("Hidden Card")
         else:
-            print(f"{self.name} of {self.suit}")
+            print(f"{self.name} of {self.suit.label}")

--- a/src/solitaire/models/color.py
+++ b/src/solitaire/models/color.py
@@ -1,0 +1,5 @@
+from enum import Enum, auto
+
+class Color(Enum):
+    RED = auto()
+    BLACK = auto()

--- a/src/solitaire/models/deck.py
+++ b/src/solitaire/models/deck.py
@@ -1,5 +1,6 @@
 import random
 from solitaire.models.card import Card
+from solitaire.models.suit import Suit
 
 class Deck:
     """
@@ -11,7 +12,7 @@ class Deck:
         Initializes a standard 52-card deck.
         """
         self.cards = []
-        for suit in Card.VALID_SUITS:
+        for suit in Suit:
             for value in range(1, 14):
                 self.cards.append(Card(suit, value))
 

--- a/src/solitaire/models/suit.py
+++ b/src/solitaire/models/suit.py
@@ -1,0 +1,12 @@
+from enum import Enum
+from solitaire.models.color import Color
+
+class Suit(Enum):
+    HEARTS = (Color.RED, "Hearts")
+    DIAMONDS = (Color.RED, "Diamonds")
+    SPADES = (Color.BLACK, "Spades")
+    CLUBS = (Color.BLACK, "Clubs")
+
+    def __init__(self, color, label):
+        self.color = color
+        self.label = label

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -61,9 +61,6 @@ def test_solitaire_setup():
     # Stock: 24 cards remaining (52 - 28)
     assert len(board.stock) == 24
 
-    # The first card in stock should be flipped, the rest should be face down (not flipped)
-    for i, card in enumerate(board.stock):
-        if i == 0:
-            assert card.flipped is True
-        else:
-            assert card.flipped is False
+    # All cards in stock should be face down
+    for card in board.stock:
+        assert card.flipped is False

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -1,22 +1,24 @@
 import pytest
 from solitaire.models.card import Card
+from solitaire.models.suit import Suit
+from solitaire.models.color import Color
 
 def test_card_initialization_valid():
     """Test creating cards with valid suits and values."""
-    card = Card("Hearts", 1)
-    assert card.suit == "Hearts"
+    card = Card(Suit.HEARTS, 1)
+    assert card.suit == Suit.HEARTS
     assert card.value == 1
     assert card._actual_name == "Ace"
     assert card.name == "Hidden Card"
-    assert card.color == "Red"
+    assert card.color == Color.RED
     assert not card.flipped
 
-    card = Card("spades", 13)
-    assert card.suit == "Spades"
+    card = Card(Suit.SPADES, 13)
+    assert card.suit == Suit.SPADES
     assert card.value == 13
     assert card._actual_name == "King"
     assert card.name == "Hidden Card"
-    assert card.color == "Black"
+    assert card.color == Color.BLACK
 
 def test_card_initialization_invalid_suit():
     """Test that invalid suits raise ValueError."""
@@ -24,22 +26,22 @@ def test_card_initialization_invalid_suit():
         Card("Joker", 1)
     
     with pytest.raises(ValueError, match="Invalid suit"):
-        Card("NotASuit", 5)
+        Card(None, 5)
 
 def test_card_initialization_invalid_value():
     """Test that invalid values raise ValueError."""
     with pytest.raises(ValueError, match="Invalid value"):
-        Card("Hearts", 0)
+        Card(Suit.HEARTS, 0)
     
     with pytest.raises(ValueError, match="Invalid value"):
-        Card("Diamonds", 14)
+        Card(Suit.DIAMONDS, 14)
     
     with pytest.raises(ValueError, match="Invalid value"):
-        Card("Clubs", -1)
+        Card(Suit.CLUBS, -1)
 
 def test_card_flip():
     """Test the flip method."""
-    card = Card("Clubs", 10)
+    card = Card(Suit.CLUBS, 10)
     assert not card.flipped
     card.flip()
     assert card.flipped
@@ -48,7 +50,7 @@ def test_card_flip():
 
 def test_card_print_full_name(capsys):
     """Test the print_full_name method."""
-    card = Card("Diamonds", 11)
+    card = Card(Suit.DIAMONDS, 11)
     card.flip()
     card.print_full_name()
     captured = capsys.readouterr()
@@ -56,7 +58,7 @@ def test_card_print_full_name(capsys):
 
 def test_card_print_full_name_unflipped(capsys):
     """Test that print_full_name shows a masked name when card is not flipped."""
-    card = Card("Diamonds", 11)
+    card = Card(Suit.DIAMONDS, 11)
     assert not card.flipped
     card.print_full_name()
     captured = capsys.readouterr()
@@ -64,7 +66,7 @@ def test_card_print_full_name_unflipped(capsys):
 
 def test_card_print_unicode_flipped(capsys):
     """Test the print_unicode method when card is flipped."""
-    card = Card("Spades", 1)
+    card = Card(Suit.SPADES, 1)
     card.flip()
     card.print_unicode()
     captured = capsys.readouterr()
@@ -73,7 +75,7 @@ def test_card_print_unicode_flipped(capsys):
 
 def test_card_print_unicode_unflipped(capsys):
     """Test that print_unicode shows the card back when card is not flipped."""
-    card = Card("Spades", 1)
+    card = Card(Suit.SPADES, 1)
     assert not card.flipped
     card.print_unicode()
     captured = capsys.readouterr()

--- a/tests/test_moves.py
+++ b/tests/test_moves.py
@@ -1,0 +1,84 @@
+import pytest
+from solitaire.models.board import Board
+from solitaire.models.card import Card
+
+def test_move_within_tableau():
+    board = Board()
+    # Ensure source pile has at least one card
+    source_idx = 1
+    dest_idx = 2
+    initial_source_len = len(board.tableau[source_idx])
+    initial_dest_len = len(board.tableau[dest_idx])
+    
+    success = board.move_card(source_type="tableau", source_idx=source_idx, 
+                              dest_type="tableau", dest_idx=dest_idx, num_cards=1)
+    
+    assert success is True
+    assert len(board.tableau[source_idx]) == initial_source_len - 1
+    assert len(board.tableau[dest_idx]) == initial_dest_len + 1
+
+def test_move_tableau_to_foundation():
+    board = Board()
+    source_idx = 0
+    dest_idx = 0
+    initial_source_len = len(board.tableau[source_idx])
+    
+    success = board.move_card(source_type="tableau", source_idx=source_idx, 
+                              dest_type="foundation", dest_idx=dest_idx)
+    
+    assert success is True
+    assert len(board.tableau[source_idx]) == initial_source_len - 1
+    assert len(board.foundation[dest_idx]) == 1
+
+def test_move_waste_to_tableau():
+    board = Board()
+    # Use draw_from_stock to put card in waste
+    board.draw_from_stock()
+    
+    dest_idx = 0
+    initial_dest_len = len(board.tableau[dest_idx])
+    
+    success = board.move_card(source_type="waste", dest_type="tableau", dest_idx=dest_idx)
+    
+    assert success is True
+    assert len(board.waste) == 0
+    assert len(board.tableau[dest_idx]) == initial_dest_len + 1
+
+def test_auto_flip_after_move():
+    board = Board()
+    # Ensure pile 1 has 2 cards, top is flipped, bottom is not.
+    assert len(board.tableau[1]) == 2
+    assert board.tableau[1][1].flipped is True
+    assert board.tableau[1][0].flipped is False
+    
+    # Move the top card away
+    board.move_card(source_type="tableau", source_idx=1, dest_type="foundation", dest_idx=0)
+    
+    # The remaining card in pile 1 should now be flipped
+    assert len(board.tableau[1]) == 1
+    assert board.tableau[1][0].flipped is True
+
+def test_move_multiple_cards_tableau():
+    board = Board()
+    # Pile 2 has 3 cards. Let's move 2 cards to pile 3.
+    # (Note: In real Solitaire only face-up cards can be moved together, 
+    # but our stub allows it for now)
+    source_idx = 2
+    dest_idx = 3
+    
+    success = board.move_card(source_type="tableau", source_idx=source_idx, 
+                              dest_type="tableau", dest_idx=dest_idx, num_cards=2)
+    
+    assert success is True
+    assert len(board.tableau[source_idx]) == 1
+    assert len(board.tableau[dest_idx]) == 6 # 4 initial + 2 moved
+
+def test_invalid_move_returns_false():
+    board = Board()
+    # Invalid source type
+    success = board.move_card(source_type="invalid", dest_type="tableau", dest_idx=0)
+    assert success is False
+    
+    # Invalid destination type
+    success = board.move_card(source_type="waste", dest_type="invalid")
+    assert success is False

--- a/tests/test_stock_logic.py
+++ b/tests/test_stock_logic.py
@@ -1,0 +1,43 @@
+from solitaire.models.board import Board
+from solitaire.models.card import Card
+
+def test_draw_from_stock():
+    board = Board()
+    initial_stock_len = len(board.stock)
+    initial_waste_len = len(board.waste)
+    
+    # Stock should be face-down initially
+    assert board.stock[0].flipped is False
+    
+    # Draw one card
+    assert board.draw_from_stock() is True
+    assert len(board.stock) == initial_stock_len - 1
+    assert len(board.waste) == 1
+    # Card in waste should be flipped
+    assert board.waste[0].flipped is True
+    # Next card in stock remains face-down
+    if board.stock:
+        assert board.stock[0].flipped is False
+    
+def test_stock_cycle():
+    board = Board()
+    stock_len = len(board.stock)
+    
+    # Draw all cards to waste
+    for i in range(stock_len):
+        assert board.draw_from_stock() is True
+        
+    assert len(board.stock) == 0
+    assert len(board.waste) == stock_len
+    # All waste cards should be flipped
+    for card in board.waste:
+        assert card.flipped is True
+    
+    # Draw again should reset stock
+    assert board.draw_from_stock() is True
+    assert len(board.stock) == stock_len
+    assert len(board.waste) == 0
+    # All stock cards should be face down after reset
+    for i in range(stock_len):
+        assert board.stock[i].flipped is False
+


### PR DESCRIPTION
This implements the logic for moving a card around the board. Currently there are no solitaire move rules being enacted, just a stub for a "is valid move" check that always returns true until rule logic is implemented. However, cards can move from within the tableau both single card and multiple. Moves in the UI are click-and-drag. Card will "snap back" to original position if an invalid destination or move is performed.

Waste pile was also implemented to show the top 3 cards at all times so the user can be aware of the two cards below the playable waste card.

Also adjusted the logic for the suit and color to depend on ENUMs for future ease of use.

Known issue that will be addressed later: Moving multiple cards from the tableau to the foundation piles breaks functionality, but this should be addressed one valid move checking is introduced.